### PR TITLE
Add paper published on SRDS 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Tendermint: Byzantine Fault Tolerance in the Age of Blockchains](https://allquantor.at/blockchainbib/pdf/buchman2016tendermint.pdf) Ethan Buchman's thesis
 - [Dissecting Tendermint](https://arxiv.org/abs/1809.09858)
 - [Correctness and Fairness of Tendermint-core Blockchains](https://arxiv.org/abs/1805.08429) Analysis of Tendermint proposer selection algorithm (p.s. algorithm is fixed and formally verified for the case of two parties by Christopher Goes https://github.com/cwgoes/tm-proposer-idris)
+- [The design, architecture and performance of the Tendermint Blockchain Network](https://doi.org/10.1109/SRDS53918.2021.00012) Overview of Tendermint's main design goals and architecture, and detailed performance evaluation (published on [SRDS 2021](https://srds21.cse.msu.edu/): [presentation](https://youtu.be/Wkket1UldYc), [pdf](https://www.inf.usi.ch/faculty/pedone/Paper/2021/srds2021a.pdf))
 
 ## Tutorials
 


### PR DESCRIPTION
I am one of the authors.

DOI: https://doi.org/10.1109/SRDS53918.2021.00012 (is not open access)
PDF version available on: https://www.inf.usi.ch/faculty/pedone/Paper/2021/srds2021a.pdf

Conference:  40th International Symposium on Reliable Distributed Systems (SRDS 2021)
 - SRDS: https://srds-conference.org/
 - 2021: https://srds21.cse.msu.edu/

The conference was virtual, the presentation is on Youtube:  https://youtu.be/Wkket1UldYc